### PR TITLE
Add immediately flag to ChangeNotification.post()

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,8 +36,10 @@ class ChangeNotification {
         this.unsubscribe = this.unsubscribe.bind(this);
     }
 
-    post(): void {
-        if (!this._posted) {
+    post(immediately = false): void {
+        if (immediately) {
+            this._notifyAll();
+        } else if (!this._posted) {
             this._posted = true;
             setTimeout(this._notifyAll.bind(this), 0);
         }


### PR DESCRIPTION
Add flag to immediately post to subscribers, synchronously, before returning.